### PR TITLE
fix: remove unused resourcedetection

### DIFF
--- a/opentelemetry_collector/templates/otel-config-gw.yaml.j2
+++ b/opentelemetry_collector/templates/otel-config-gw.yaml.j2
@@ -22,7 +22,7 @@ service:
   pipelines:
     metrics:
       receivers: [ otlp ]
-      processors: [ batch, resourcedetection ]
+      processors: [ batch ]
       exporters: [ logging, otlp ]
 
   extensions: [ health_check ]

--- a/opentelemetry_collector/templates/otel-config.yaml.j2
+++ b/opentelemetry_collector/templates/otel-config.yaml.j2
@@ -15,9 +15,6 @@ receivers:
 
 processors:
   batch:
-  resource:
-  resourcedetection:
-    detectors: [env, system, ec2]
 
 exporters:
   logging:
@@ -31,7 +28,7 @@ service:
   pipelines:
     metrics:
       receivers: [hostmetrics]
-      processors: [batch, resourcedetection]
+      processors: [batch]
       exporters: [logging, otlp]
 
   extensions: [health_check]


### PR DESCRIPTION
For compatibility with the otelcol we would remove the features that are not available on that one. The best would be to have multiple template to have different configurations depending on the distribution. 