### PR TITLE
ci: force reset the CrowdStrike CID (linux)

### DIFF
--- a/caos.ansible_roles/roles/install_crowdstrike_falcon/tasks/main.yaml
+++ b/caos.ansible_roles/roles/install_crowdstrike_falcon/tasks/main.yaml
@@ -21,7 +21,7 @@
 - include_tasks: win.yaml
 
 - name: 'Register host with CrowdStrike (Linux)'
-  shell: /opt/CrowdStrike/falconctl -s --cid={{ falcon_customer_id }}
+  shell: /opt/CrowdStrike/falconctl -s -f --cid={{ falcon_customer_id }}
   become: true
   when: ansible_facts['os_family'] not in ['Darwin', 'Windows']
 


### PR DESCRIPTION
This is useful when re-running this role on already provisioned hosts. If attempting to set the CID on a host that is already configured, it can fail with the below error:

```CID is set, but -f was not specified```

A similar way to achieve this on mac does not seem to be available.