### PR TITLE
chore: deprecate ansible.builtin.include

### DIFF
--- a/caos.ansible_roles/roles/assert_no_service/tasks/main.yaml
+++ b/caos.ansible_roles/roles/assert_no_service/tasks/main.yaml
@@ -1,5 +1,5 @@
 ---
 
-- include: "assert-no-service-{{ ansible_system }}.yaml"
+- ansible.builtin.include_tasks: "assert-no-service-{{ ansible_system }}.yaml"
 
 ...

--- a/caos.ansible_roles/roles/assert_ownership/tasks/main.yaml
+++ b/caos.ansible_roles/roles/assert_ownership/tasks/main.yaml
@@ -6,6 +6,6 @@
   when: (username is not defined) or (username | length == 0)
 
 
-- include: "check-{{ ansible_system }}.yaml"
+- ansible.builtin.include_tasks: "check-{{ ansible_system }}.yaml"
 
 ...

--- a/caos.ansible_roles/roles/assert_privileged_caps/tasks/main.yaml
+++ b/caos.ansible_roles/roles/assert_privileged_caps/tasks/main.yaml
@@ -1,5 +1,5 @@
 ---
 
-- include: "check_{{ ansible_system }}.yaml"
+- ansible.builtin.include_tasks: "check_{{ ansible_system }}.yaml"
 
 ...

--- a/caos.ansible_roles/roles/assert_process_running/tasks/main.yaml
+++ b/caos.ansible_roles/roles/assert_process_running/tasks/main.yaml
@@ -1,5 +1,5 @@
 ---
 
-- include: "assert-process-running-{{ ansible_system }}.yaml"
+- ansible.builtin.include_tasks: "assert-process-running-{{ ansible_system }}.yaml"
 
 ...

--- a/caos.ansible_roles/roles/assert_service_status/tasks/main.yaml
+++ b/caos.ansible_roles/roles/assert_service_status/tasks/main.yaml
@@ -1,5 +1,5 @@
 ---
 
-- include: "assert-service-{{ ansible_system }}.yaml"
+- ansible.builtin.include_tasks: "assert-service-{{ ansible_system }}.yaml"
 
 ...

--- a/caos.ansible_roles/roles/assert_version/tasks/main.yaml
+++ b/caos.ansible_roles/roles/assert_version/tasks/main.yaml
@@ -1,5 +1,5 @@
 ---
 
-- include: "assert-version-{{ ansible_system }}.yaml"
+- ansible.builtin.include_tasks: "assert-version-{{ ansible_system }}.yaml"
 
 ...

--- a/caos.ansible_roles/roles/cleanup/tasks/main.yaml
+++ b/caos.ansible_roles/roles/cleanup/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 
-- include: "service-{{ ansible_system }}.yaml"
-- include: "package-{{ ansible_os_family }}.yaml"
-- include: "files-{{ ansible_system }}.yaml"
+- ansible.builtin.include_tasks: "service-{{ ansible_system }}.yaml"
+- ansible.builtin.include_tasks: "package-{{ ansible_os_family }}.yaml"
+- ansible.builtin.include_tasks: "files-{{ ansible_system }}.yaml"
 
 ...

--- a/caos.ansible_roles/roles/docker_install/tasks/install-docker-RedHat.yaml
+++ b/caos.ansible_roles/roles/docker_install/tasks/install-docker-RedHat.yaml
@@ -1,5 +1,5 @@
 ---
 
-- include: install-docker-CentOS.yaml
+- ansible.builtin.include_tasks: install-docker-CentOS.yaml
 
 ...

--- a/caos.ansible_roles/roles/ec2_instance/tasks/main.yml
+++ b/caos.ansible_roles/roles/ec2_instance/tasks/main.yml
@@ -5,6 +5,6 @@
     msg: instance_id variable must be specified
   when: (instance_id is not defined) or (instance_id | length == 0)
 
-- include: "ec2-{{ action }}.yml"
+- ansible.builtin.include_tasks: "ec2-{{ action }}.yml"
 
 ...

--- a/caos.ansible_roles/roles/nr_repo_setup/tasks/main.yaml
+++ b/caos.ansible_roles/roles/nr_repo_setup/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
 
-- include: "repo-{{ ansible_distribution }}.yaml"
+- ansible.builtin.include_tasks: "repo-{{ ansible_distribution }}.yaml"
   when: ansible_distribution != "MacOSX"
 
 - name:

--- a/caos.ansible_roles/roles/package_install/tasks/main.yaml
+++ b/caos.ansible_roles/roles/package_install/tasks/main.yaml
@@ -6,6 +6,6 @@
     state: "latest"
   when: target_version | length == 0
 
-- include: "package-{{ ansible_os_family }}.yaml"
+- ansible.builtin.include_tasks: "package-{{ ansible_os_family }}.yaml"
 
 ...

--- a/caos.ansible_roles/roles/package_uninstall/tasks/main.yaml
+++ b/caos.ansible_roles/roles/package_uninstall/tasks/main.yaml
@@ -1,5 +1,5 @@
 ---
 
-- include: "package-{{ ansible_os_family }}.yaml"
+- ansible.builtin.include_tasks: "package-{{ ansible_os_family }}.yaml"
 
 ...

--- a/caos.ansible_roles/roles/service_status/tasks/main.yaml
+++ b/caos.ansible_roles/roles/service_status/tasks/main.yaml
@@ -1,5 +1,5 @@
 ---
 
-- include: "service_{{ action }}_{{ ansible_system }}.yaml"
+- ansible.builtin.include_tasks: "service_{{ action }}_{{ ansible_system }}.yaml"
 
 ...


### PR DESCRIPTION
ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.