### PR TITLE
NR-164383 feat: assert_permissions role

### DIFF
--- a/caos.ansible_roles/roles/assert_permissions/README.md
+++ b/caos.ansible_roles/roles/assert_permissions/README.md
@@ -1,0 +1,12 @@
+Assert file permissions.
+
+```yaml
+
+- name: Assert permissions
+  include_role:
+    name: caos.ansible_roles.assert_permissions
+  vars:
+    files:
+      /etc/fstab: "0644"
+      /this/is/another/path: "0765"
+```

--- a/caos.ansible_roles/roles/assert_permissions/tasks/check-Linux.yaml
+++ b/caos.ansible_roles/roles/assert_permissions/tasks/check-Linux.yaml
@@ -1,0 +1,15 @@
+---
+
+- name: stat on files
+  stat:
+    path: "{{ item.key }}"
+  register: st
+  loop: "{{ files | dict2items }}"
+
+- name: fail if permissions are incorrect
+  fail:
+    msg: "{{ item.item.key }} permissions {{ item.stat.mode }} should be {{ item.item.value }}"
+  when: item.item.value  != item.stat.mode
+  loop: "{{ st.results }}"
+
+...

--- a/caos.ansible_roles/roles/assert_permissions/tasks/main.yaml
+++ b/caos.ansible_roles/roles/assert_permissions/tasks/main.yaml
@@ -1,0 +1,5 @@
+---
+
+- ansible.builtin.include_tasks: "check-{{ ansible_system }}.yaml"
+
+...

--- a/caos.ansible_roles/roles/assert_permissions/vars/main.yaml
+++ b/caos.ansible_roles/roles/assert_permissions/vars/main.yaml
@@ -1,0 +1,10 @@
+# unix permission mask ~ "0754"
+bin_mode: ""
+# files array (ensure ordered iteration)
+# files:
+#  - file: /some/file
+#    mode: "0755"
+#  - file: /another/file
+#    mode: "0600"
+files: []
+


### PR DESCRIPTION
Assert file permissions.

```yaml

- name: Assert permissions
  include_role:
    name: caos.ansible_roles.assert_permissions
  vars:
    files:
      /etc/fstab: "0644"
      /this/is/another/path: "0765"
```