### PR TITLE
NR-164383 feat: role for newrelic-cli

### DIFF
--- a/caos.ansible_roles/roles/newrelic_cli/README.md
+++ b/caos.ansible_roles/roles/newrelic_cli/README.md
@@ -1,0 +1,14 @@
+Install agents using New Relic CLI
+
+```yaml
+- name: install agent via newrelic-cli
+  include_role:
+    name: caos.ansible_roles.newrelic_cli
+  vars:
+    repo_endpoint: "https://download.newrelic.com/"
+    recipe: "newrelic-infra"
+    region: "STAGING" # US | EU | STAGING
+    nr_api_key: "user-api-key"
+    nr_account_id: "nr-account-id"
+
+```

--- a/caos.ansible_roles/roles/newrelic_cli/tasks/main.yml
+++ b/caos.ansible_roles/roles/newrelic_cli/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+
+# Currently package from production is installed because stg does not have https and nr-cli verifies this
+# Until this is fixed we need to clean metadata to avoid error: "Not using downloaded repomd.xml because it is older than what we have"
+- name: clean metadata
+  command: yum clean metadata
+  when: ansible_pkg_mgr == 'yum'
+
+- name: Download newrelic-cli installer
+  get_url:
+    url: https://raw.githubusercontent.com/newrelic/newrelic-cli/master/scripts/install.sh
+    dest: /tmp/newrelic-cli-install.sh
+    mode: '0111'
+
+- name: Install newrelic-cli
+  shell: yes | /tmp/newrelic-cli-install.sh
+
+- name: Install agent via newrelic-cli
+  no_log: true
+  shell: NEW_RELIC_DOWNLOAD_URL="{{ repo_endpoint }}" NEW_RELIC_REGION="{{ region }}" NEW_RELIC_API_KEY={{ nr_api_key }} NEW_RELIC_ACCOUNT_ID={{ nr_account_id }} /usr/local/bin/newrelic install -n {{ recipe }} --debug -y

--- a/caos.ansible_roles/roles/newrelic_cli/vars/main.yml
+++ b/caos.ansible_roles/roles/newrelic_cli/vars/main.yml
@@ -1,0 +1,5 @@
+repo_endpoint: "https://nr-downloads-ohai-staging.s3.amazonaws.com/"
+recipe: "newrelic-infra"
+region: "STAGING"
+nr_api_key: ""
+nr_account_id: ""


### PR DESCRIPTION
Install agents using New Relic CLI

```yaml
- name: install agent via newrelic-cli
  include_role:
    name: caos.ansible_roles.newrelic_cli
  vars:
    repo_endpoint: "https://download.newrelic.com/"
    recipe: "newrelic-infra"
    region: "STAGING" # US | EU | STAGING
    nr_api_key: "user-api-key"
    nr_account_id: "nr-account-id"

```