### PR TITLE
NR-164383 feat: assert version on Windows

### DIFF
--- a/caos.ansible_roles/roles/assert_version/README.md
+++ b/caos.ansible_roles/roles/assert_version/README.md
@@ -1,6 +1,7 @@
 Assert application version.
 
 ```yaml
+# Linux
 - name: assert version
   include_role:
     name: caos.ansible_roles.assert_version
@@ -10,4 +11,14 @@ Assert application version.
         version: "1.36.1"
       - exec: "otelcol-contrib --version"
         version: "0.70.0"
+
+# Windows
+
+- name: Assert version
+  include_role:
+    name: caos.ansible_roles.assert_version
+  vars:
+    target_versions:
+      - exec: '"C:\Program Files\New Relic\newrelic-infra\newrelic-infra.exe" "--version"'
+        version: "1.47.2"
 ```

--- a/caos.ansible_roles/roles/assert_version/tasks/assert-version-Win32NT.yaml
+++ b/caos.ansible_roles/roles/assert_version/tasks/assert-version-Win32NT.yaml
@@ -1,0 +1,14 @@
+---
+
+- name: Assert expected version
+  ansible.windows.win_command: '{{ item.exec }}'
+  register: check
+  loop: "{{ target_versions }}"
+
+- name: Stdout from version grep
+  ansible.builtin.assert:
+    that: "{{ item.stdout | regex_search('([0-9\\.]+)', '\\1') | first  == item.item.version }}"
+    fail_msg: "{{ item.stdout | regex_search('([0-9\\.]+)', '\\1') | first }} does not match {{ item.item.version }}"
+  loop: "{{ check.results }}"
+
+...

--- a/caos.ansible_roles/roles/assert_version/vars/main.yaml
+++ b/caos.ansible_roles/roles/assert_version/vars/main.yaml
@@ -1,8 +1,13 @@
 ---
 
+# Linux
 #target_versions:
 #   - exec: "/usr/bin/newrelic-infra --version"
 #    version: "1.34.0"
+# Windows:
+#   - exec: "C:\Program Files\New Relic\newrelic-infra\newrelic-infra.exe" "--version"
+#     version: "1.34.0"
+#
 target_versions: []
 
 ...


### PR DESCRIPTION
Assert application version.

```yaml
# Windows

- name: Assert version
  include_role:
    name: caos.ansible_roles.assert_version
  vars:
    target_versions:
      - exec: '"C:\Program Files\New Relic\newrelic-infra\newrelic-infra.exe" "--version"'
        version: "1.47.2"
```