### PR TITLE
Include tasks only when applicable

### DIFF
--- a/caos.ansible_roles/roles/install_crowdstrike_falcon/tasks/apt.yaml
+++ b/caos.ansible_roles/roles/install_crowdstrike_falcon/tasks/apt.yaml
@@ -16,6 +16,4 @@
   apt:
     deb: /tmp/falcon-sensor.deb
     state: present
-  when: inventory_hostname is search(item.hostname)
-  loop: "{{ apt }}"
 ...

--- a/caos.ansible_roles/roles/install_crowdstrike_falcon/tasks/dnf.yaml
+++ b/caos.ansible_roles/roles/install_crowdstrike_falcon/tasks/dnf.yaml
@@ -17,8 +17,4 @@
     name: /tmp/falcon-sensor.rpm
     state: present
     disable_gpg_check: true
-  when: inventory_hostname is search(item.hostname)
-  loop: "{{ dnf }}"
-
-
 ...

--- a/caos.ansible_roles/roles/install_crowdstrike_falcon/tasks/main.yaml
+++ b/caos.ansible_roles/roles/install_crowdstrike_falcon/tasks/main.yaml
@@ -14,11 +14,17 @@
   when: ansible_facts['os_family'] != 'Windows'
 
 - include_tasks: dnf.yaml
+  when: ansible_pkg_mgr == 'dnf'
 - include_tasks: yum.yaml
+  when: ansible_pkg_mgr == 'yum'
 - include_tasks: apt.yaml
+  when: ansible_pkg_mgr == 'apt'
 - include_tasks: zyp.yaml
+  when: ansible_pkg_mgr == 'zypper'
 - include_tasks: mac.yaml
+  when: ansible_os_family == 'Darwin'
 - include_tasks: win.yaml
+  when: ansible_os_family == 'Windows'
 
 - name: 'Register host with CrowdStrike (Linux)'
   shell: /opt/CrowdStrike/falconctl -s -f --cid={{ falcon_customer_id }}

--- a/caos.ansible_roles/roles/install_crowdstrike_falcon/tasks/yum.yaml
+++ b/caos.ansible_roles/roles/install_crowdstrike_falcon/tasks/yum.yaml
@@ -16,6 +16,4 @@
   yum:
     name: /tmp/falcon-sensor.rpm
     state: present
-  when: inventory_hostname is search(item.hostname)
-  loop: "{{ yum }}"
 ...

--- a/caos.ansible_roles/roles/install_crowdstrike_falcon/tasks/zyp.yaml
+++ b/caos.ansible_roles/roles/install_crowdstrike_falcon/tasks/zyp.yaml
@@ -19,13 +19,11 @@
   zypper:
     name: libnl3-200
     state: present
-  when: inventory_hostname is search(item.hostname) and ansible_architecture == "aarch64"
-  loop: "{{ zyp }}"
+  when: ansible_architecture == "aarch64"
 
 - name: 'Install the obtained RPM with nodeps (aarch64)'
   raw: 'sudo rpm -i --nodeps /tmp/falcon-sensor.rpm'
-  when: inventory_hostname is search(item.hostname) and ansible_architecture == "aarch64"
-  loop: "{{ zyp }}"
+  when: ansible_architecture == "aarch64"
 
 # Otherwise, we install normally.
 
@@ -34,6 +32,5 @@
     name: /tmp/falcon-sensor.rpm
     state: present
     disable_gpg_check: true
-  when: inventory_hostname is search(item.hostname) and ansible_architecture != "aarch64"
-  loop: "{{ zyp }}"
+  when: ansible_architecture == "aarch64"
 ...


### PR DESCRIPTION
I see this as an improvement, since each task file gets simpler. If, however, this was done intentionally, please let me know!

I am doing this since I am working on deriving the crowdstrike-falcon pkg to be installed from ansible facts, so that if the hostname would not match, it could still be matched based on those. 

Since this is not specific to that work, I am submitting it separately. 
