### PR TITLE
chore: replace deprecated `include`

### DIFF
--- a/caos.ansible_roles/roles/dockerized_agent/tasks/main.yml
+++ b/caos.ansible_roles/roles/dockerized_agent/tasks/main.yml
@@ -12,4 +12,4 @@
     mode: 0644
 
 - name: Run docker-docker
-  include: "docker-compose-{{ ansible_distribution }}.yaml"
+  include_tasks: "docker-compose-{{ ansible_distribution }}.yaml"


### PR DESCRIPTION
replace deprecated include: feature in ansible (updated on the fargate task) fixing:
```
ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.
```