### PR TITLE
fix: ensure appropriate permissions for logrotate state file

### DIFF
--- a/caos.ansible_roles/roles/logrotate/tasks/main.yml
+++ b/caos.ansible_roles/roles/logrotate/tasks/main.yml
@@ -12,6 +12,11 @@
 - include_tasks: "logrotate-{{ ansible_distribution }}.yaml"
   when: ansible_distribution != "SLES"
 
+- name: make sure state file has the appropriate permissions
+  file:
+    path: "/var/lib/logrotate/status"
+    mode: "640"
+
 - name: force logrotate
   shell: "[ -f {{ item }} ] && logrotate -f {{ item }}"
   loop:


### PR DESCRIPTION
I have started seeing this error on Ubuntu 22.04 and Debian Bullseye:

```
error: state file /var/lib/logrotate/status is world-readable and thus can be locked from other unprivileged users. Skipping lock acquisition...
```