### PR TITLE
fix: update file permissions only if it exists

### DIFF
--- a/caos.ansible_roles/roles/logrotate/tasks/main.yml
+++ b/caos.ansible_roles/roles/logrotate/tasks/main.yml
@@ -14,6 +14,7 @@
 
 - name: make sure state file has the appropriate permissions
   file:
+    state: "file"
     path: "/var/lib/logrotate/status"
     mode: "640"
 


### PR DESCRIPTION
From the [Ansible docs](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/file_module.html):

> If `file`, even with other options (such as `mode`), the file will be modified if it exists but will NOT be created if it does not exist.