### PR TITLE
Added dearmor for debian Trixie

### DIFF
--- a/caos.ansible_roles/roles/nr_repo_setup/tasks/repo-Debian.yaml
+++ b/caos.ansible_roles/roles/nr_repo_setup/tasks/repo-Debian.yaml
@@ -30,9 +30,23 @@
 - name: download New Relic Infra Repo GPG key (modern method for newer Debian/Ubuntu)
   get_url:
     url: "{{ gpg_key_url }}"
-    dest: /etc/apt/keyrings/newrelic-infra.gpg
+    dest: /etc/apt/keyrings/newrelic-infra-armored.gpg
     mode: '0644'
   when: not apt_key_exists.stat.exists
+
+- name: Dearmor GPG key for Debian Trixie (sqv requires binary format)
+  shell: gpg --dearmor < /etc/apt/keyrings/newrelic-infra-armored.gpg > /etc/apt/keyrings/newrelic-infra.gpg
+  args:
+    creates: /etc/apt/keyrings/newrelic-infra.gpg
+  when: not apt_key_exists.stat.exists and ansible_distribution_release == "trixie"
+
+- name: Copy armored key for non-Trixie releases
+  copy:
+    src: /etc/apt/keyrings/newrelic-infra-armored.gpg
+    dest: /etc/apt/keyrings/newrelic-infra.gpg
+    remote_src: yes
+    mode: '0644'
+  when: not apt_key_exists.stat.exists and ansible_distribution_release != "trixie"
 
 - name: remove New Relic Infra APT repository (from previous runs)
   apt_repository:


### PR DESCRIPTION
## Debian Trixie GPG Key Fix

### Problem
Debian Trixie uses `sqv` (Sequoia) for GPG signature verification, which:
1. Requires GPG keys in **binary (dearmored) format** instead of ASCII-armored
2. Rejects **SHA-1 signatures** (deprecated since 2026-02-01)

### Solution
- Use the new SHA-256 signed GPG key for Trixie: `newrelic_rpm_key_sha256.gpg`
- Add a **dearmor step** to convert the key to binary format for `sqv` compatibility

### Changes
1. Set different GPG key URL for Trixie (`newrelic_rpm_key_sha256.gpg`)
2. Download key to temporary file (`newrelic-infra-armored.gpg`)
3. For Trixie: Dearmor key using `gpg --dearmor` → `newrelic-infra.gpg`
4. For other releases: Copy armored key as-is → `newrelic-infra.gpg`

### Affected Systems
- **Debian Trixie (13)**: Uses new key + dearmor step
- **Other Debian/Ubuntu**: No changes to existing behavior